### PR TITLE
Update CI deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,14 @@
+sudo: false
 language: ruby
-rvm:
-- 2.3.3
-
-before_script:
- - chmod +x ./script/cibuild # or do this locally and commit
-
-# Assume bundler is being used, therefore
-# the `install` step will run `bundle install` by default.
-script: ./script/cibuild
-
+rvm: 2.3.3
+script: ./deploy/cibuild
+deploy:
+    provider: pages
+    skip-cleanup: true
+    keep-history: true
+    github-token: "o+0COW1WQfqHxeeCT+MSs0bG25tSwV0XG5T2LRkF7k6FwZ/ec3WxFOuSW4u3hHz6ZUysdBMokGDV8ZRszogZ7Vk/DMMj54vcFIwnWrcg4G5Btym47i0lywjJcSz2jQW2JlB9REcLwm/wODF7lPH4oYh+1N4CusPJ+RlnqUkeOT6GiBJBYMYOxDitx9EJBsbUD+VfThdynrZb2UPcu53uxQICq9PmkTeM1raWG19efMLV5e1+P4NhTUQlZ7ENTWEtA4xzvMxzzrw+ET0HXdhr7KLNSEFyI7QRO6kALA3oy5kPGu6WEd8MBzFBzKDoj1z75S89+FVR1233+L/h1tqZeAUP+61WIKb2jnBUFA4Akgl8EaUhn+B4JeJMI9/qI7KujpsWf5BWA7Kd5Ht050KJf47rYAa1daTfW8m/gt3ApVPrl+VzcKhPQ1hc6qJgnAD7M5C7X7CDBdgQal4J56rdVE6HoGtiWxOMcvj7Yyd0fZRGAlD0m6B9mU4EFAni2OYdVrb9SkbD/DBZiCLvjaLE+en6niEvpGpi194GeshJAID77cyH6VX9JtDoxM4pfLF5s8EBcuMbiaFLDyYyVfRvQMeYUcBTGBJs7finLKOUFls4nnIyK9VvmU3o0JgCeEZQIf1EndE2cy+lUulH1Vn5adWguif89rZpvHf4wI7+FM4="
+    on:
+        branch: master
 env:
   global:
-  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
-
-sudo: false # route your build to the container-based infrastructure for a faster build
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer

--- a/Gemfile
+++ b/Gemfile
@@ -31,3 +31,6 @@ gem "html-proofer"
 
 # Add sitemap
 gem 'jekyll-sitemap'
+
+# Add travis-CI
+gem 'travis'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 This is the source code for my [blog](ljvmiranda921.github.io). It's a static
 website powered by [Jekyll](https://jekyllrb.com/). 
 
-The build script can be found on `./script/cibuild`. It runs the `html-proofer`
+The build script can be found on `./deploy/cibuild`. It runs the `html-proofer`
 gem which checks for inconsistencies in the generated page. Whenever you want
 to create a new post, or develop the site, always make a Pull Request so that
 the proofer can investigate the changes you've made.

--- a/deploy/cibuild
+++ b/deploy/cibuild
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e # halt script on error
+
+bundle exec jekyll build
+bundle exec htmlproofer ./_site --disable-external

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -e # halt script on error
-
-bundle exec jekyll build
-bundle exec htmlproofer ./_site --disable-external


### PR DESCRIPTION
It seems that github pages is still being deployed even if Travis encounters an error. By explicitly creating a deploy script, we should be able to solve that problem