### PR TITLE
Patch dependencies for vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,17 +20,17 @@ gem "minima", "~> 2.0"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
    gem "jekyll-feed", "~> 0.6"
-   gem 'jekyll-seo-tag'
+   gem "jekyll-seo-tag"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 # HTML Proofer
 gem "html-proofer"
 
 # Add sitemap
-gem 'jekyll-sitemap'
+gem "jekyll-sitemap"
 
 # Update some dependencies bsaed on depdendabot
 gem "nokogiri", "~> 1.11.0"

--- a/Gemfile
+++ b/Gemfile
@@ -34,3 +34,6 @@ gem 'jekyll-sitemap'
 
 # Add travis-CI
 gem 'travis'
+
+# Update some dependencies bsaed on depdendabot
+gem "nokogiri", "~> 1.11.0"

--- a/Gemfile
+++ b/Gemfile
@@ -32,8 +32,5 @@ gem "html-proofer"
 # Add sitemap
 gem 'jekyll-sitemap'
 
-# Add travis-CI
-gem 'travis'
-
 # Update some dependencies bsaed on depdendabot
 gem "nokogiri", "~> 1.11.0"


### PR DESCRIPTION
Updates nokogiri to >= 1.11.0 to resolve some vulnerabilities.
Update Gemfile and remove unnecessary deps + some cleanups